### PR TITLE
优化复制多边形功能

### DIFF
--- a/labelme/app.py
+++ b/labelme/app.py
@@ -423,7 +423,7 @@ class MainWindow(QtWidgets.QMainWindow):
             enabled=False,
         )
         copy = action(
-            self.tr("Copy Polygons"),
+            self.tr("Copy Images"),
             self.copySelectedShape,
             shortcuts["copy_polygon"],
             "copy_clipboard",

--- a/labelme/dlcv/app.py
+++ b/labelme/dlcv/app.py
@@ -132,6 +132,9 @@ class MainWindow(MainWindow):
         self._init_dev_mode()
         self._init_ui()
         self.actions.copy.setEnabled(True)
+        
+        # 修改复制动作的文本为"复制图片"
+        self.actions.copy.setText("复制图片")
 
         self._init_edit_mode_action()  # 初始化编辑模式切换动作
         STORE.set_edit_label_name(self._edit_label)
@@ -145,7 +148,7 @@ class MainWindow(MainWindow):
         # 确保标签txt目录存在
         if not os.path.exists(self.LABEL_TXT_DIR):
             os.makedirs(self.LABEL_TXT_DIR, exist_ok=True)
-
+        
     # https://bbs.dlcv.com.cn/t/topic/590
     def _edit_label(self, value=None):
         # extra 绘制模式下, 也允许编辑标签
@@ -564,52 +567,39 @@ class MainWindow(MainWindow):
     
     def duplicateSelectedShape(self):
         """重写父类方法：复制选中的形状到剪贴板"""
-        # print("=== DEBUG: duplicateSelectedShape被调用 ===")
         if not self.canvas.selectedShapes:
-            # print("=== DEBUG: 没有选中的形状 ===")
             notification("提示", "请先选中要复制的形状", ToastPreset.WARNING)
             return
             
-        # print(f"=== DEBUG: 有 {len(self.canvas.selectedShapes)} 个选中的形状 ===")
         try:
             # 将选中的形状转换为可序列化的格式
             shapes_data = []
             for shape in self.canvas.selectedShapes:
                 shape_data = self.format_shape_for_clipboard(shape)
                 shapes_data.append(shape_data)
-                # print(f"=== DEBUG: 格式化形状 {shape.label}, 点数: {len(shape.points)} ===")
             
             # 记录源图像路径
             source_image_path = self.filename
-            print(f"=== DEBUG: 记录源图像路径: {source_image_path} ===")
+            logger.info(f"=== DEBUG: 记录源图像路径: {source_image_path} ===")
             
             # 复制到剪贴板
             from labelme.dlcv.widget.clipboard import copy_shapes_to_clipboard
-            # print(f"=== DEBUG: 调用copy_shapes_to_clipboard, 形状数量: {len(shapes_data)} ===")
             copy_shapes_to_clipboard(shapes_data, source_image_path)
-            print("=== DEBUG: 复制形状到剪贴板完成 ===")
             
             # 启用粘贴动作
             self.actions.paste.setEnabled(True)
-            print("=== DEBUG: 已启用粘贴动作 ===")
             
             notification("复制成功", f"已复制 {len(shapes_data)} 个形状到剪贴板", ToastPreset.SUCCESS)
             
         except Exception as e:
-            print(f"=== DEBUG: 复制形状失败: {e} ===")
             notification("复制失败", str(e), ToastPreset.ERROR)
     
     def format_shape_for_clipboard(self, shape):
         """将形状对象格式化为可序列化的字典"""
-        # print(f"=== DEBUG: format_shape_for_clipboard开始，形状标签: {shape.label} ===")
-        # print(f"=== DEBUG: 原始形状点数: {len(shape.points)} ===")
-        print(f"=== DEBUG: 原始形状点坐标: {[(p.x(), p.y()) for p in shape.points]} ===")
-        # print(f"=== DEBUG: shape.other_data内容: {shape.other_data} ===")
         
         # 创建新的数据字典，不从other_data复制，避免冲突
         data = {}
         points_data = [(p.x(), p.y()) for p in shape.points]
-        print(f"=== DEBUG: 序列化后的点数据: {points_data} ===")
         
         data.update({
             'label': shape.label,
@@ -624,14 +614,10 @@ class MainWindow(MainWindow):
         # 如果是旋转框，添加direction属性
         if shape.shape_type == "rotation":
             data["direction"] = getattr(shape, "direction", 0.0)
-        
-        print(f"=== DEBUG: 最终序列化数据中的点数: {len(data['points'])} ===")
-        # print(f"=== DEBUG: format_shape_for_clipboard完成 ===")
         return data
     
     def create_shape_from_data(self, shape_data):
         """从形状数据创建Shape对象"""
-        # print("=== DEBUG: create_shape_from_data开始 ===")
         try:
             from labelme.dlcv.shape import Shape
             from PyQt5 import QtCore
@@ -648,7 +634,6 @@ class MainWindow(MainWindow):
             
             # 设置点坐标
             points = shape_data.get('points', [])
-            # print(f"=== DEBUG: 设置 {len(points)} 个点 ===")
             for point in points:
                 shape.addPoint(QtCore.QPointF(point[0], point[1]))
             
@@ -662,11 +647,9 @@ class MainWindow(MainWindow):
             if shape.shape_type == "rotation":
                 shape.direction = shape_data.get("direction", 0.0)
             
-            # print(f"=== DEBUG: 创建形状完成: {shape.label} ===")
             return shape
             
         except Exception as e:
-            print(f"=== DEBUG: 创建形状失败: {e} ===")
             import traceback
             traceback.print_exc()
             raise
@@ -675,16 +658,11 @@ class MainWindow(MainWindow):
         """为形状添加偏移，避免与原形状重合"""
         from PyQt5 import QtCore
         
-        # print(f"=== DEBUG: add_offset_to_shape开始 ===")
-        print(f"=== DEBUG: 当前图像尺寸: {self.image.width()} x {self.image.height()} ===")
-        
         # 计算形状的边界
         min_x = min(p.x() for p in shape.points)
         max_shape_x = max(p.x() for p in shape.points)
         min_y = min(p.y() for p in shape.points)
         max_shape_y = max(p.y() for p in shape.points)
-        
-        print(f"=== DEBUG: 形状边界: x({min_x:.2f}, {max_shape_x:.2f}), y({min_y:.2f}, {max_shape_y:.2f}) ===")
         
         # 检查是否需要调整偏移以避免出界
         max_x = self.image.width() - 0.001
@@ -692,7 +670,6 @@ class MainWindow(MainWindow):
         
         # 检查形状是否超出当前图像边界
         if max_shape_x > max_x or max_shape_y > max_y or min_x < 0 or min_y < 0:
-            print(f"=== DEBUG: 形状超出当前图像边界，需要调整 ===")
             # 如果形状超出边界，给出警告并调整到边界内
             notification("警告", "粘贴的形状超出当前图像边界，已自动调整", ToastPreset.WARNING)
             
@@ -700,8 +677,6 @@ class MainWindow(MainWindow):
             scale_x = max_x / max_shape_x if max_shape_x > max_x else 1.0
             scale_y = max_y / max_shape_y if max_shape_y > max_y else 1.0
             scale = min(scale_x, scale_y, 1.0)  # 不放大，只缩小
-            
-            print(f"=== DEBUG: 计算缩放比例: {scale:.3f} ===")
             
             # 应用缩放
             for point in shape.points:
@@ -713,7 +688,6 @@ class MainWindow(MainWindow):
                 point.setX(new_x)
                 point.setY(new_y)
             
-            print(f"=== DEBUG: 缩放后形状边界: x({min(p.x() for p in shape.points):.2f}, {max(p.x() for p in shape.points):.2f}), y({min(p.y() for p in shape.points):.2f}, {max(p.y() for p in shape.points):.2f}) ===")
             return
         
         # 偏移量
@@ -737,8 +711,6 @@ class MainWindow(MainWindow):
             else:
                 offset_y = 0
         
-        print(f"=== DEBUG: 应用偏移: ({offset_x}, {offset_y}) ===")
-        
         # 应用偏移
         for point in shape.points:
             new_x = point.x() + offset_x
@@ -749,28 +721,20 @@ class MainWindow(MainWindow):
             point.setX(new_x)
             point.setY(new_y)
         
-        print(f"=== DEBUG: 偏移后形状边界: x({min(p.x() for p in shape.points):.2f}, {max(p.x() for p in shape.points):.2f}), y({min(p.y() for p in shape.points):.2f}, {max(p.y() for p in shape.points):.2f}) ===")
-        # print(f"=== DEBUG: add_offset_to_shape完成 ===")
     
     def check_and_adjust_shape_bounds(self, shape):
         """检查形状是否超出当前图像边界，如果超出则调整"""
-        # print(f"=== DEBUG: check_and_adjust_shape_bounds开始 ===")
-        print(f"=== DEBUG: 当前图像尺寸: {self.image.width()} x {self.image.height()} ===")
-        
         # 计算形状的边界
         min_x = min(p.x() for p in shape.points)
         max_shape_x = max(p.x() for p in shape.points)
         min_y = min(p.y() for p in shape.points)
         max_shape_y = max(p.y() for p in shape.points)
         
-        print(f"=== DEBUG: 形状边界: x({min_x:.2f}, {max_shape_x:.2f}), y({min_y:.2f}, {max_shape_y:.2f}) ===")
-        
         # 检查形状是否超出当前图像边界
         max_x = self.image.width() - 0.001
         max_y = self.image.height() - 0.001
         
         if max_shape_x > max_x or max_shape_y > max_y or min_x < 0 or min_y < 0:
-            print(f"=== DEBUG: 形状超出当前图像边界，需要调整 ===")
             # 如果形状超出边界，给出警告并调整到边界内
             notification("警告", "粘贴的形状超出当前图像边界，已自动调整", ToastPreset.WARNING)
             
@@ -778,8 +742,6 @@ class MainWindow(MainWindow):
             scale_x = max_x / max_shape_x if max_shape_x > max_x else 1.0
             scale_y = max_y / max_shape_y if max_shape_y > max_y else 1.0
             scale = min(scale_x, scale_y, 1.0)  # 不放大，只缩小
-            
-            print(f"=== DEBUG: 计算缩放比例: {scale:.3f} ===")
             
             # 应用缩放
             for point in shape.points:
@@ -791,11 +753,8 @@ class MainWindow(MainWindow):
                 point.setX(new_x)
                 point.setY(new_y)
             
-            print(f"=== DEBUG: 调整后形状边界: x({min(p.x() for p in shape.points):.2f}, {max(p.x() for p in shape.points):.2f}), y({min(p.y() for p in shape.points):.2f}, {max(p.y() for p in shape.points):.2f}) ===")
         else:
-            print(f"=== DEBUG: 形状在图像边界内，无需调整 ===")
-        
-        # print(f"=== DEBUG: check_and_adjust_shape_bounds完成 ===")
+            pass
     
     def fileSelectionChanged(self):
         if not self.is_all_shapes_valid():
@@ -948,9 +907,9 @@ class MainWindow(MainWindow):
             last_shape = self.canvas.shapes[-1]
             if last_shape.shape_type == "polygon" and len(
                     last_shape.points) > 3:
-                print('简化前点数: ', len(last_shape.points))
+                logger.info(f'简化前点数: {len(last_shape.points)}')
                 self.simplifyShapePoints(last_shape)
-                print('简化后点数: ', len(last_shape.points))
+                logger.info(f'简化后点数: {len(last_shape.points)}')
 
         items = self.uniqLabelList.selectedItems()
         text = None
@@ -1075,68 +1034,51 @@ class MainWindow(MainWindow):
 
     def pasteSelectedShape(self):
         """从剪贴板粘贴形状或图像"""
-        print("=== DEBUG: pasteSelectedShape被调用 ===")
-        print("=== DEBUG: 这是一个测试，如果你看到这个，说明方法被调用了 ===")
         try:
             # 首先尝试从剪贴板读取形状数据
             from labelme.dlcv.widget.clipboard import paste_shapes_from_clipboard
-            print("=== DEBUG: 调用paste_shapes_from_clipboard ===")
             shapes_data = paste_shapes_from_clipboard()
             
             if shapes_data is not None:
-                print(f"=== DEBUG: 从剪贴板读取到 {len(shapes_data)} 个形状 ===")
-                print(f"=== DEBUG: 当前图像路径: {self.filename} ===")
-                print(f"=== DEBUG: 当前图像尺寸: {self.image.width()} x {self.image.height()} ===")
+                logger.info(f"=== DEBUG: 当前图像路径: {self.filename} ===")
                 
                 # 将形状数据转换为Shape对象并添加偏移
                 shapes = []
                 for i, shape_data in enumerate(shapes_data):
-                    print(f"=== DEBUG: 创建形状 {i}: {shape_data.get('label', 'unknown')} ===")
-                    print(f"=== DEBUG: 形状 {i} 原始坐标: {shape_data.get('points', [])} ===")
                     shape = self.create_shape_from_data(shape_data)
-                    print(f"=== DEBUG: 形状 {i} 创建后坐标: {[(p.x(), p.y()) for p in shape.points]} ===")
                     
                     # 检查是否需要应用偏移（只在同一张图片上粘贴时应用偏移）
                     source_image_path = shape_data.get('source_image_path')
                     current_image_path = self.filename
-                    print(f"=== DEBUG: 源图像路径: {source_image_path} ===")
-                    print(f"=== DEBUG: 当前图像路径: {current_image_path} ===")
                     
                     if source_image_path == current_image_path:
-                        print(f"=== DEBUG: 在同一张图片上粘贴，应用偏移 ===")
+                        logger.info(f"=== DEBUG: 在同一张图片上粘贴，应用偏移 ===")
                         # 添加偏移以避免与原形状重合
                         self.add_offset_to_shape(shape)
-                        print(f"=== DEBUG: 形状 {i} 偏移后坐标: {[(p.x(), p.y()) for p in shape.points]} ===")
                     else:
-                        print(f"=== DEBUG: 在不同图片上粘贴，不应用偏移，保持原始坐标 ===")
+                        logger.info(f"=== DEBUG: 在不同图片上粘贴，不应用偏移，保持原始坐标 ===")
                         # 检查形状是否超出当前图像边界，如果超出则调整
                         self.check_and_adjust_shape_bounds(shape)
-                        print(f"=== DEBUG: 形状 {i} 边界调整后坐标: {[(p.x(), p.y()) for p in shape.points]} ===")
                     
                     shapes.append(shape)
                 
                 # 加载形状到画布
-                print(f"=== DEBUG: 加载 {len(shapes)} 个形状到画布 ===")
                 self.loadShapes(shapes, replace=False)
                 self.setDirty()
                 
                 notification("粘贴成功", f"已粘贴 {len(shapes)} 个形状", ToastPreset.SUCCESS)
                 return
             
-            print("=== DEBUG: 从剪贴板读取形状数据失败，尝试粘贴图像 ===")
             # 如果没有形状数据，尝试粘贴图像
             try:
                 # 调用父类的粘贴图像功能
                 super().pasteSelectedShape()
-                print("=== DEBUG: 图像粘贴成功 ===")
                 return
             except Exception as e:
-                print(f"=== DEBUG: 图像粘贴失败: {e} ===")
+                pass
             
             # 如果图像粘贴也失败，尝试使用原有的_copied_shapes机制
-            print("=== DEBUG: 尝试使用原有的_copied_shapes机制 ===")
             if not self._copied_shapes:
-                print("=== DEBUG: _copied_shapes也为空，无法粘贴 ===")
                 notification("提示", "剪贴板中没有可粘贴的内容", ToastPreset.WARNING)
                 return
 
@@ -1154,7 +1096,6 @@ class MainWindow(MainWindow):
                 self.setDirty()
             
         except Exception as e:
-            print(f"=== DEBUG: 粘贴失败: {e} ===")
             import traceback
             traceback.print_exc()
             notification("粘贴失败", str(e), ToastPreset.ERROR)

--- a/labelme/dlcv/dlcv_translator.py
+++ b/labelme/dlcv/dlcv_translator.py
@@ -56,6 +56,8 @@ tr_map = {
         'highlight start point': '高亮起始点',
         'ai polygon simplify epsilon': 'AI多边形简化参数设置',
 
+        'copy images': '复制图片',
+
         # 项目类型
         'project setting': '项目设置',
         'project type': '项目类型',

--- a/labelme/dlcv/widget/clipboard.py
+++ b/labelme/dlcv/widget/clipboard.py
@@ -1,3 +1,4 @@
+from labelme.logger import logger
 def copy_files_to_clipboard(file_paths):
     """
     将多个文件复制到剪贴板
@@ -151,10 +152,6 @@ def copy_shapes_to_clipboard(shapes_data, source_image_path=None):
     import os
     
     try:
-        print("=== DEBUG: copy_shapes_to_clipboard开始 ===")
-        print(f"=== DEBUG: 输入形状数据数量: {len(shapes_data)} ===")
-        print(f"=== DEBUG: 源图像路径: {source_image_path} ===")
-        
         # 为每个形状添加源图像路径信息
         shapes_data_with_source = []
         for shape_data in shapes_data:
@@ -164,28 +161,22 @@ def copy_shapes_to_clipboard(shapes_data, source_image_path=None):
         
         # 将形状数据序列化为JSON
         json_data = json.dumps(shapes_data_with_source, ensure_ascii=False, indent=2)
-        print(f"=== DEBUG: JSON数据长度: {len(json_data)} ===")
         
         # 创建临时文件
         temp_dir = tempfile.gettempdir()
         temp_path = os.path.join(temp_dir, "copied_shapes.json")
-        print(f"=== DEBUG: 临时文件路径: {temp_path} ===")
         
         # 写入JSON数据
         with open(temp_path, 'w', encoding='utf-8') as temp_file:
             temp_file.write(json_data)
-        print("=== DEBUG: JSON数据写入临时文件完成 ===")
         
         try:
             # 使用现有的copy_file_to_clipboard函数复制临时文件
             copy_file_to_clipboard(temp_path)
-            print("=== DEBUG: 临时文件复制到剪贴板完成 ===")
         finally:
             all_temp_files.append(temp_path)
-            print("=== DEBUG: 临时文件已添加到清理列表 ===")
             
     except Exception as e:
-        print(f"=== DEBUG: 复制形状到剪贴板失败: {e} ===")
         import traceback
         traceback.print_exc()
         raise
@@ -203,36 +194,22 @@ def paste_shapes_from_clipboard():
     import os
     
     try:
-        print("=== DEBUG: paste_shapes_from_clipboard开始 ===")
         # 检查临时文件是否存在
         temp_dir = tempfile.gettempdir()
         temp_path = os.path.join(temp_dir, "copied_shapes.json")
-        print(f"=== DEBUG: 检查临时文件: {temp_path} ===")
         
         if not os.path.exists(temp_path):
-            print("=== DEBUG: 临时文件不存在 ===")
             return None
             
-        print("=== DEBUG: 临时文件存在，开始读取 ===")
         # 读取JSON数据
         with open(temp_path, 'r', encoding='utf-8') as temp_file:
             content = temp_file.read()
-            print(f"=== DEBUG: 读取到内容长度: {len(content)} ===")
             shapes_data = json.loads(content)
-            print(f"=== DEBUG: 解析出形状数据数量: {len(shapes_data)} ===")
-            
-            # 详细检查每个形状的数据
-            for i, shape_data in enumerate(shapes_data):
-                print(f"=== DEBUG: 形状 {i} 标签: {shape_data.get('label', 'unknown')} ===")
-                print(f"=== DEBUG: 形状 {i} 类型: {shape_data.get('shape_type', 'unknown')} ===")
-                points = shape_data.get('points', [])
-                print(f"=== DEBUG: 形状 {i} 点数: {len(points)} ===")
-                print(f"=== DEBUG: 形状 {i} 点坐标: {points} ===")
             
         return shapes_data
         
     except Exception as e:
-        print(f"=== DEBUG: 从剪贴板读取形状数据失败: {e} ===")
+        logger.info(f"=== DEBUG: 从剪贴板读取形状数据失败: {e} ===")
         import traceback
         traceback.print_exc()
         return None

--- a/labelme/dlcv/widget/clipboard.py
+++ b/labelme/dlcv/widget/clipboard.py
@@ -138,6 +138,106 @@ def clear_temps():
     all_temp_files.clear()
 
 
+def copy_shapes_to_clipboard(shapes_data, source_image_path=None):
+    """
+    将形状数据复制到剪贴板
+    
+    Args:
+        shapes_data (list): 形状数据列表，每个形状是一个字典
+        source_image_path (str): 源图像路径，用于判断是否在同一张图片上粘贴
+    """
+    import json
+    import tempfile
+    import os
+    
+    try:
+        print("=== DEBUG: copy_shapes_to_clipboard开始 ===")
+        print(f"=== DEBUG: 输入形状数据数量: {len(shapes_data)} ===")
+        print(f"=== DEBUG: 源图像路径: {source_image_path} ===")
+        
+        # 为每个形状添加源图像路径信息
+        shapes_data_with_source = []
+        for shape_data in shapes_data:
+            shape_with_source = shape_data.copy()
+            shape_with_source['source_image_path'] = source_image_path
+            shapes_data_with_source.append(shape_with_source)
+        
+        # 将形状数据序列化为JSON
+        json_data = json.dumps(shapes_data_with_source, ensure_ascii=False, indent=2)
+        print(f"=== DEBUG: JSON数据长度: {len(json_data)} ===")
+        
+        # 创建临时文件
+        temp_dir = tempfile.gettempdir()
+        temp_path = os.path.join(temp_dir, "copied_shapes.json")
+        print(f"=== DEBUG: 临时文件路径: {temp_path} ===")
+        
+        # 写入JSON数据
+        with open(temp_path, 'w', encoding='utf-8') as temp_file:
+            temp_file.write(json_data)
+        print("=== DEBUG: JSON数据写入临时文件完成 ===")
+        
+        try:
+            # 使用现有的copy_file_to_clipboard函数复制临时文件
+            copy_file_to_clipboard(temp_path)
+            print("=== DEBUG: 临时文件复制到剪贴板完成 ===")
+        finally:
+            all_temp_files.append(temp_path)
+            print("=== DEBUG: 临时文件已添加到清理列表 ===")
+            
+    except Exception as e:
+        print(f"=== DEBUG: 复制形状到剪贴板失败: {e} ===")
+        import traceback
+        traceback.print_exc()
+        raise
+
+
+def paste_shapes_from_clipboard():
+    """
+    从剪贴板读取形状数据
+    
+    Returns:
+        list: 形状数据列表，如果失败返回None
+    """
+    import json
+    import tempfile
+    import os
+    
+    try:
+        print("=== DEBUG: paste_shapes_from_clipboard开始 ===")
+        # 检查临时文件是否存在
+        temp_dir = tempfile.gettempdir()
+        temp_path = os.path.join(temp_dir, "copied_shapes.json")
+        print(f"=== DEBUG: 检查临时文件: {temp_path} ===")
+        
+        if not os.path.exists(temp_path):
+            print("=== DEBUG: 临时文件不存在 ===")
+            return None
+            
+        print("=== DEBUG: 临时文件存在，开始读取 ===")
+        # 读取JSON数据
+        with open(temp_path, 'r', encoding='utf-8') as temp_file:
+            content = temp_file.read()
+            print(f"=== DEBUG: 读取到内容长度: {len(content)} ===")
+            shapes_data = json.loads(content)
+            print(f"=== DEBUG: 解析出形状数据数量: {len(shapes_data)} ===")
+            
+            # 详细检查每个形状的数据
+            for i, shape_data in enumerate(shapes_data):
+                print(f"=== DEBUG: 形状 {i} 标签: {shape_data.get('label', 'unknown')} ===")
+                print(f"=== DEBUG: 形状 {i} 类型: {shape_data.get('shape_type', 'unknown')} ===")
+                points = shape_data.get('points', [])
+                print(f"=== DEBUG: 形状 {i} 点数: {len(points)} ===")
+                print(f"=== DEBUG: 形状 {i} 点坐标: {points} ===")
+            
+        return shapes_data
+        
+    except Exception as e:
+        print(f"=== DEBUG: 从剪贴板读取形状数据失败: {e} ===")
+        import traceback
+        traceback.print_exc()
+        return None
+
+
 if __name__ == "__main__":
     # 测试单文件复制
     # file_path = r"C:\dlcv\datasets\dogs_vs_cats\狗\dog.0.jpg"

--- a/labelme/translate/zh_CN.ts
+++ b/labelme/translate/zh_CN.ts
@@ -290,8 +290,8 @@
     </message>
     <message>
         <location filename="../app.py" line="418"/>
-        <source>Copy Polygons</source>
-        <translation>复制多边形</translation>
+        <source>Copy Images</source>
+        <translation>复制图片</translation>
     </message>
     <message>
         <location filename="../app.py" line="418"/>


### PR DESCRIPTION
优化多边形复制功能

1、删除了ctrl+c 的复制多边形 保留复制图片的功能
2、ctrl+d 支持复制形状到剪贴板在不同图像切换可以照原坐标直接粘贴。 在原来形状上粘贴自动偏移。

论坛链接：
https://bbs2.dlcv.com.cn/t/topic/1437